### PR TITLE
feat: TreeTrunk 시각화 개선 및 월별 응답 시각화 적용

### DIFF
--- a/src/components/TreeTrunk.tsx
+++ b/src/components/TreeTrunk.tsx
@@ -1,26 +1,27 @@
 import { useMemo } from "react";
 import treeBg from "../assets/images/treeHome.png";
 
-// 기존의 고정값은 제거합니다
 const COLORS = ["#4CAF50", "#81C784", "#AED581", "#66BB6A", "#A5D6A7", "#26A69A"];
 
 function TreeTrunk({
   answeredCount,
   totalCount,
 }: {
-  answeredCount: number;
-  totalCount: number;
+  answeredCount: number; // 실제 답변한 질문 수
+  totalCount: number;    // 전체 가능한 질문 수
 }) {
   const baseWidth = 600;
-  const radius = baseWidth * 0.3;
+  const radius = baseWidth * 0.35;
   const centerX = baseWidth * 0.5;
-  const centerY = baseWidth * 0.45;
+  const centerY = baseWidth * 0.36;
+
+  const circleCount = answeredCount ; // 시각화용 추후에 원이 부족하면 곱하기 하기
 
   const circles = useMemo(() => {
     type Circle = {
       xPercent: number;
       yPercent: number;
-      sizePercent: number;
+      sizePx: number;
       color: string;
       delay: number;
     };
@@ -29,25 +30,25 @@ function TreeTrunk({
     const MAX_ATTEMPTS = 1000;
 
     let attempts = 0;
-    while (newCircles.length < answeredCount && attempts < MAX_ATTEMPTS) {
+    while (newCircles.length < circleCount && attempts < MAX_ATTEMPTS) {
       const angle = Math.random() * 2 * Math.PI;
       const r = Math.sqrt(Math.random()) * radius;
       const x = centerX + r * Math.cos(angle);
       const y = centerY + r * Math.sin(angle);
-      const size = Math.random() * 30 + 10;
+      const size = Math.random() * 14 + 10;// px 단위로 고정
 
       const isOverlapping = newCircles.some((circle) => {
         const dx = (circle.xPercent / 100) * baseWidth - x;
         const dy = (circle.yPercent / 100) * baseWidth - y;
         const distance = Math.sqrt(dx * dx + dy * dy);
-        return distance < ((circle.sizePercent / 100) * baseWidth + size) / 2 + 1;
+        return distance < (circle.sizePx + size) / 2 + 1;
       });
 
       if (!isOverlapping) {
         newCircles.push({
           xPercent: (x / baseWidth) * 100,
           yPercent: (y / baseWidth) * 100,
-          sizePercent: (size / baseWidth) * 100,
+          sizePx: size,
           color: COLORS[Math.floor(Math.random() * COLORS.length)],
           delay: Math.random() * 2,
         });
@@ -57,7 +58,7 @@ function TreeTrunk({
     }
 
     return newCircles;
-  }, [answeredCount]);
+  }, [circleCount]);
 
   return (
     <div className="flex flex-col items-center gap-2 w-full rounded-xl px-4">
@@ -77,8 +78,9 @@ function TreeTrunk({
             style={{
               left: `${circle.xPercent}%`,
               top: `${circle.yPercent}%`,
-              width: `${circle.sizePercent}%`,
-              height: `${circle.sizePercent}%`,
+              width: `${circle.sizePx}px`,
+              height: `${circle.sizePx}px`,
+              borderRadius: "50%", // 완전한 원
               backgroundColor: circle.color,
               opacity: 0.85,
               zIndex: 1,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,12 +51,11 @@ function Home() {
     const fetchAnsweredCount = async () => {
       try {
         const start = getStartOfMonth();
-      const end = getToday();
-      const res = await getPeriodDiary(start, end);
-      const count = res.count * 3;
-      setAnsweredCount(count);
-
-      alert(`이번 달 총 ${count}개의 질문에 답변했어요!`);
+        const end = getToday();
+        const res = await getPeriodDiary(start, end);
+  
+        setAnsweredCount(res.count); 
+  
       } catch (error) {
         console.error("이번 달 일기 수 조회 실패", error);
       }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #52 

## 📝 작업 내용

### API 연동
- `getPeriodDiary(start, end)` 함수 사용
- 월의 시작일 (`YYYY-MM-01`) ~ 오늘 날짜로 조회 범위 지정
- 응답 데이터의 `count` 값을 기반으로 사용자 응답 수(`answeredCount`) 계산

### TreeTrunk 연동
- API에서 받은 `answeredCount`를 시각화에 전달
- `totalCount`는 이번 달 일수 × 3 으로 계산하여 최대 시각화 개수 설정
- `answeredCount`, `totalCount`를 `TreeTrunk`에 prop으로 전달

## 연동 API
- **GET** `/api/diary/period`
  - `query`: `start`, `end` (ISO 8601 string)
  - `response`: `{ diaries: DiaryItem[], count: number }`


