### PR TITLE
feat: 주간 레포트 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "date-fns": "^4.1.0",
         "js-cookie": "^3.0.5",
         "react": "^18.2.0",
+        "react-calendar": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.3",
@@ -1879,7 +1880,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2150,6 +2151,15 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/accepts": {
@@ -3522,6 +3532,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4149,6 +4171,18 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4166,6 +4200,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "license": "MIT",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/merge-descriptors": {
@@ -4226,6 +4276,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minimatch": {
@@ -4351,6 +4410,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -4625,6 +4693,31 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
+      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {
@@ -5496,6 +5589,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^4.1.0",
     "js-cookie": "^3.0.5",
     "react": "^18.2.0",
+    "react-calendar": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.3",

--- a/src/utils/formatWeekKey.ts
+++ b/src/utils/formatWeekKey.ts
@@ -1,0 +1,10 @@
+// utils/formatWeekKey.ts
+import { getStartAndEndOfWeek } from "./getStartAndEndOfWeek";
+
+export function formatWeekKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.toLocaleString("en-US", { month: "short" });
+  const monday = getStartAndEndOfWeek(date).start;
+  const weekNum = Math.ceil((monday.getDate() + 6) / 7);
+  return `${year} ${month} week${weekNum}`;
+}

--- a/src/utils/getStartAndEndOfWeek.ts
+++ b/src/utils/getStartAndEndOfWeek.ts
@@ -1,0 +1,15 @@
+// src/utils/getStartAndEndOfWeek.ts
+export function getStartAndEndOfWeek(date: Date): { start: Date; end: Date } {
+    const day = date.getDay(); // 일요일: 0, 월요일: 1 ...
+    const diffToMonday = (day === 0 ? -6 : 1) - day;
+    const monday = new Date(date);
+    monday.setDate(date.getDate() + diffToMonday);
+    monday.setHours(0, 0, 0, 0);
+  
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    sunday.setHours(23, 59, 59, 999);
+  
+    return { start: monday, end: sunday };
+  }
+  


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #54 

## 📝 작업 내용

1. 주간 범위 계산
getStartAndEndOfWeek(date) 유틸로 선택한 날짜가 포함된 주간의 월~일 범위를 계산하여 API 요청에 활용

2. AreaChart 데이터 구성
dayKeys = ["Mon", "Tue", ..., "Sun"] 으로 순서 변경
getDayNameFromDate(date) 보정 함수로 getDay() 값(일요일=0)을 월요일 기준으로 재정렬
일기당 최대 3개까지 요일별 count 적용

3. 워드 클라우드 데이터 구성
diary.diary의 JSON을 파싱하여 .content를 추출
추출된 텍스트를 extractWordFrequency로 처리 후 워드 클라우드에 전달

4. 스와이프 기능
Swiper를 사용해 ±2주 범위의 주간을 좌우로 이동
onSlideChange에서 selectedDate를 변경하여 useEffect 재실행




